### PR TITLE
Fixed a misspelled word

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ grunt.initConfig({
     // The destination for the build stylesheet
     sheet: "stylesheet.css",
     // A mustache template used to render your sprites in a css file. (Optional)
-    tempateUrl: "path/to/template.mustache"
+    templateUrl: "path/to/template.mustache"
   }
 })
 ```


### PR DESCRIPTION
"templateUrl" has a typo in your README. FTFY.
