### PR TITLE
Support for prefix-option, allowing empty if required

### DIFF
--- a/tasks/spritesheet.js
+++ b/tasks/spritesheet.js
@@ -2,7 +2,7 @@
  * grunt-spritesheet
  * https://github.com/nicholasstephan/grunt-spritesheet
  *
- * Mostly just a fork of Ensignten's `grunt-spritesmith` plugin, but 
+ * Mostly just a fork of Ensignten's `grunt-spritesmith` plugin, but
  * with support for a multiple, and pixel doubled, spritesheets.
  * https://github.com/Ensighten/grunt-spritesmith
  *
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
 	// Create an image from `srcFiles`, with name `destImage`, and pass
 	// coordinates to callback.
 	function mkSprite(srcFiles, destImage, options, callback) {
-		
+
 		options.src = srcFiles,
 
 		grunt.verbose.writeln('Options passed to Spritesmth:', JSON.stringify(options));
@@ -103,7 +103,7 @@ module.exports = function(grunt) {
 
 					Object.getOwnPropertyNames(coordinates).forEach(function(file) {
 						var name = path.basename(file, ext);
-						name = prefix + "-" + name;
+						name = ('string' === typeof data.prefix ? data.prefix : prefix + '-') + name;
 
 						file = coordinates[file];
 
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
 			if(dbl.length) {
 				var dblPromise = new Promise();
 				promises.push(dblPromise);
-				
+
 				var dblSprite = path.dirname(sprite) + "/" + path.basename(sprite, ext) + "@2x" + ext;
 				var dblUrl = path.relative(path.dirname(sheet), path.dirname(dblSprite)) + '/' + path.basename(dblSprite);
 
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
 						Object.getOwnPropertyNames(coordinates).forEach(function (file) {
 							var name = path.basename(file, '@2x' + ext);
 							name = prefix + "-" + name;
-							
+
 							file = coordinates[file];
 
 							coords.dbl.push({
@@ -170,7 +170,7 @@ module.exports = function(grunt) {
 
 			var css = mustache.render(template, coords);
 			var sheetDir = path.dirname(sheet);
-			
+
 			grunt.file.mkdir(sheetDir);
 			fs.writeFileSync(sheet, css, 'utf8');
 

--- a/tasks/spritesheet.js
+++ b/tasks/spritesheet.js
@@ -143,7 +143,7 @@ module.exports = function(grunt) {
 
 						Object.getOwnPropertyNames(coordinates).forEach(function (file) {
 							var name = path.basename(file, '@2x' + ext);
-							name = prefix + "-" + name;
+							name = ('string' === typeof data.prefix ? data.prefix : prefix + '-') + name;
 
 							file = coordinates[file];
 


### PR DESCRIPTION
I'm trying to achieve this with a custom mustache-template:

``` mustache
icon,
i[class^='icon-'],
i[class*=' icon-'] {
  display: inline-block;
  background-image: url({{&std.0.sprite}});
}

{{#std}}
icon.{{&name}},
icon[name='{{&name}}'],
i.icon-{{&name}} {
  width: {{width}}px;
  height: {{height}}px;
  background-position: -{{x}}px -{{y}}px;
}
{{/std}}
```

So, I've added a some images i.e. `sprites/email.png` and now can I use them as follows:

``` html
<icon name="email">
<i class="icon-email"></i>
```

Of course, to achieve this is required an empty-prefix value.

What do you think?
